### PR TITLE
'Korean (한국어)' is more suitable than 'Chosun Son (조선말)'.

### DIFF
--- a/datedropper.js
+++ b/datedropper.js
@@ -1034,7 +1034,7 @@
 				}
 			},
 			'ko' : {
-				name : '조선말',
+				name : '한국어',
 				gregorian : true,
 				months : {
 					short: [


### PR DESCRIPTION
Proposal to change the translation notation of korea
'Korean (한국어)' is more suitable than 'Chosun Son (조선말)'.

'Chosun Son (조선말)' is a word that is mainly used to describe the language used in North Korea in Japan.
In the sense that North Korea and South Korea use the same language system, 'Korean (한국어)' seems more appropriate.