### PR TITLE
Fix position after scrolling when a modal's opened

### DIFF
--- a/datedropper.js
+++ b/datedropper.js
@@ -1377,8 +1377,8 @@
 			if(!picker.element.hasClass('picker-modal')){
 				var
 					input = picker.input,
-					left = input.offset().left + input.outerWidth()/2,
-					top = input.offset().top + input.outerHeight();
+					left =  input.outerWidth()/2,
+					top =   input.outerHeight();
 				picker.element.css({
 					'left' : left,
 					'top' : top
@@ -2067,7 +2067,7 @@
 						class: 'picker'
 					})
 				})
-				.appendTo('body');
+				.appendTo($("input[data-id='"+id+"']").closest('.input-prepend'));
 
 				picker = {
 					id : id,


### PR DESCRIPTION
The Datedropper3 remains at the same position relative to the page and does not respect the position of the element it was initialized on, because modal is fixed positioning and Datedropper3 is absolute. We could provide an option for append Datedropper3 to each '.input-prepend' and then I also noticed where it was calculating the position of the Datedropper3 it was taking input.offset()..... , 
so I change that and now it works. ....
Best Regards.